### PR TITLE
Update Prepare_DDP_GUI.py

### DIFF
--- a/Prepare_DDP_GUI.py
+++ b/Prepare_DDP_GUI.py
@@ -289,7 +289,7 @@ ISRC (12 chars):'
 
 				logString = check_allowed_chars(take_name,logString)
 
-				marker_name = "#" + take_name # prefixes the take's name with "#". This will be the name of our "#" markers #Track-Name|ISRC=XYZ|PERFORMER=XYZ
+				marker_name = "#TITLE=" + take_name # prefixes the take's name with "#TITLE=". This will be the name of our "#" markers #Track-Name|ISRC=XYZ|PERFORMER=XYZ
 				
 				logString = logString + '\n#' + str(format(ItemIndex, '02d')) + ' ' + take_name
 				logString = logString + " - " + str(math.floor(item_length/60)) + ":" + str( format(int((item_length) - (math.floor(item_length/60)*60)), '02d') )


### PR DESCRIPTION
It's now possible to export tracks using markers as render bounds in Reaper. Everything works great with the script, but one issue is that titles are saved as "#title|PERFORMER=example" instead of "#TITLE=title|PERFORMER=example".  Updating the script to use the later would permit to use the appropriate wildcard $marker(#TITLE)[|] while rendering, eg. "\$timelineorder - $marker(#TITLE)[|]".